### PR TITLE
Adding a more descriptive warning about Drupal 9 on Pantheon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-# Experimental Repo For Running Drupal 9 with Pantheon's Build Tools and CircleCI Orb
+# Drupal 9 with Pantheon's Build Tools and CircleCI Orb
 
 This repository is a stripped down version of the fuller [pantheon-systems/example-drops-8-composer](https://github.com/pantheon-systems/example-drops-8-composer) which shows how Drupal 8 can be run on Pantheon with various git hosts and CI services using [Pantheon's Build Tools](https://pantheon.io/docs/guides/build-tools). This repo shows only Drupal 9 + GitHub + Pantheon and uses Build Tools wrapped in [Pantheon CircleCI Orb](https://github.com/pantheon-systems/circleci-orb).
 
-At this point this repository is meant for experimentation only.
+
+_Warining: Drupal 9 sets a higher required version for MariaDB than is currently available on Pantheon. [This repository uses patches to circumvent installation errors related to the database version](https://github.com/pantheon-systems/drupal-9-with-circleci-orb/blob/e86429c338ec3064965bc7a6bc7bd47ec0f03b81/composer.json#L44)_. Pantheon engineering is working to make a higher version available in the coming months. Until the higher version is available, we do not recommend switching your production websites to Drupal 9.
 
 To create a copy of this repository including a separate GitHub repo, a CircleCI configuration, and a Pantheon sandbox, run this command. Be sure to replace `machine-name-for-new-site` with a machine name of your choice.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository is a stripped down version of the fuller [pantheon-systems/example-drops-8-composer](https://github.com/pantheon-systems/example-drops-8-composer) which shows how Drupal 8 can be run on Pantheon with various git hosts and CI services using [Pantheon's Build Tools](https://pantheon.io/docs/guides/build-tools). This repo shows only Drupal 9 + GitHub + Pantheon and uses Build Tools wrapped in [Pantheon CircleCI Orb](https://github.com/pantheon-systems/circleci-orb).
 
 
-_Warining: Drupal 9 sets a higher required version for MariaDB than is currently available on Pantheon. [This repository uses patches to circumvent installation errors related to the database version](https://github.com/pantheon-systems/drupal-9-with-circleci-orb/blob/e86429c338ec3064965bc7a6bc7bd47ec0f03b81/composer.json#L44)_. Pantheon engineering is working to make a higher version available in the coming months. Until the higher version is available, we do not recommend switching your production websites to Drupal 9.
+_Warning: Drupal 9 sets a higher required version for MariaDB than is currently available on Pantheon. [This repository uses patches to circumvent installation errors related to the database version](https://github.com/pantheon-systems/drupal-9-with-circleci-orb/blob/e86429c338ec3064965bc7a6bc7bd47ec0f03b81/composer.json#L44)_. Pantheon engineering is working to make a higher version available in the coming months. Until the higher version is available, we do not recommend switching your production websites to Drupal 9.
 
 To create a copy of this repository including a separate GitHub repo, a CircleCI configuration, and a Pantheon sandbox, run this command. Be sure to replace `machine-name-for-new-site` with a machine name of your choice.
 


### PR DESCRIPTION
This PR removes the word "experimental" and adds a warning about mariaDB. 